### PR TITLE
Fix outdated copyright notice and free memory stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ alias toadfetch="(tput rmam; toadfetch; tput smam)"
 `toadfetch` is licesned under the GNU General Public License v3 or later.
 ```
 toadfetch, a superfast alternative to neofetch
-Copyright (C) 2023 Capta1nT0ad
+Copyright (C) 2024 Capta1nT0ad
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ alias toadfetch="(tput rmam; toadfetch; tput smam)"
 `toadfetch` is licesned under the GNU General Public License v3 or later.
 ```
 toadfetch, a superfast alternative to neofetch
-Copyright (C) 2022 Capta1nT0ad
+Copyright (C) 2023 Capta1nT0ad
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-echo -e "\033[34;1m(i) toadfetch Installer, (c) 2022 Capta1nT0ad."
+echo -e "\033[34;1m(i) toadfetch Installer, (c) 2023 Capta1nT0ad."
 echo -e '\033[34;1m(i) Installing python dependencies...'
 echo -e "     - Installing 'command'..."
 python3 -m pip install command 1> /dev/null

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-echo -e "\033[34;1m(i) toadfetch Installer, (c) 2023 Capta1nT0ad."
+echo -e "\033[34;1m(i) toadfetch Installer, (c) 2024 Capta1nT0ad."
 echo -e '\033[34;1m(i) Installing python dependencies...'
 echo -e "     - Installing 'command'..."
 python3 -m pip install command 1> /dev/null

--- a/toadfetch.py
+++ b/toadfetch.py
@@ -96,9 +96,9 @@ memory_total_pretty = memory_pretty_split[0]
 memory_total = int(memory_total_pretty.removeprefix("MemTotal:        ").removesuffix(" kB")) / 1000
 
 # Used memory
-memory_used_pretty = memory_pretty_split[2]
+memory_used_pretty = memory_pretty_split[1]
 
-memory_used_str = memory_used_pretty.removeprefix("MemAvailable:    ").removesuffix(" kB")
+memory_used_str = memory_used_pretty.removeprefix("MemFree:    ").removesuffix(" kB")
 
 memory_used_int_kb = int(memory_used_str)
 memory_used_int_mb = memory_used_int_kb / 1000


### PR DESCRIPTION
After forgetting it was 2024 and no longer 2023, I changed the copyright notice in README.md and install.sh, and in toadfetch.py I just changed the line split index and removed the correct prefix to use MemFree instead of MemAvailable. Haven’t tested… but I’m pretty sure it works fine where it did before. Easy 4-line fix, but I know the _master toad_ is reluctant to change anything here, so may this pull request live forever in the ‘closed’ tab without being merged.